### PR TITLE
WIP: Integrate data repo transfer2022

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Before you work on any non-trivial code contribution it's best to first create a
 4. You should run:
 
    ```
-   pip install -U pip setuptools -e .[develop]
+   pip install -U pip setuptools -e .[develop,transfer]
    ```
 
    to be able to import the package under development in the Python REPL and installing the required development dependencies.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Python 3.9+ is required.
 pip install vptstools
 ```
 
+In case you also need the tools/services to run the data transfers (sftp, S3), make sure to install the additional dependencies to transfer files:
+
+```
+pip install vptstools[transfer]
+```
+
 Included modules/commands:
 
 ### odimh5 module

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,11 @@ exclude =
 # `pip install vptstools[PDF]` like:
 # PDF = ReportLab; RXP
 
-# Add here test requirements (semicolon/line-separated)
+transfer =
+    boto3
+    paramiko
+
+# Add here develop requirements (semicolon/line-separated)
 develop =
     setuptools
     pytest

--- a/src/vptstools/s3_list_helper.py
+++ b/src/vptstools/s3_list_helper.py
@@ -1,0 +1,113 @@
+# From https://stackoverflow.com/questions/35803027/retrieving-subfolders-names-in-s3-bucket-from-boto3
+
+import os
+import boto3
+from collections import namedtuple
+from operator import attrgetter
+
+
+S3Obj = namedtuple('S3Obj', ['key', 'mtime', 'size', 'ETag'])
+
+
+def s3list(bucket, path, start=None, end=None, recursive=True, list_dirs=True,
+           list_objs=True, limit=None):
+    """
+    Iterator that lists a bucket's objects under path, (optionally) starting with
+    start and ending before end.
+
+    If recursive is False, then list only the "depth=0" items (dirs and objects).
+
+    If recursive is True, then list recursively all objects (no dirs).
+
+    Args:
+        bucket:
+            a boto3.resource('s3').Bucket().
+        path:
+            a directory in the bucket.
+        start:
+            optional: start key, inclusive (may be a relative path under path, or
+            absolute in the bucket)
+        end:
+            optional: stop key, exclusive (may be a relative path under path, or
+            absolute in the bucket)
+        recursive:
+            optional, default True. If True, lists only objects. If False, lists
+            only depth 0 "directories" and objects.
+        list_dirs:
+            optional, default True. Has no effect in recursive listing. On
+            non-recursive listing, if False, then directories are omitted.
+        list_objs:
+            optional, default True. If False, then directories are omitted.
+        limit:
+            optional. If specified, then lists at most this many items.
+
+    Returns:
+        an iterator of S3Obj.
+
+    Examples:
+        # set up
+        >>> s3 = boto3.resource('s3')
+        ... bucket = s3.Bucket('bucket-name')
+
+        # iterate through all S3 objects under some dir
+        >>> for p in s3list(bucket, 'some/dir'):
+        ...     print(p)
+
+        # iterate through up to 20 S3 objects under some dir, starting with foo_0010
+        >>> for p in s3list(bucket, 'some/dir', limit=20, start='foo_0010'):
+        ...     print(p)
+
+        # non-recursive listing under some dir:
+        >>> for p in s3list(bucket, 'some/dir', recursive=False):
+        ...     print(p)
+
+        # non-recursive listing under some dir, listing only dirs:
+        >>> for p in s3list(bucket, 'some/dir', recursive=False, list_objs=False):
+        ...     print(p)
+"""
+    kwargs = dict()
+    if start is not None:
+        if not start.startswith(path):
+            start = os.path.join(path, start)
+        # note: need to use a string just smaller than start, because
+        # the list_object API specifies that start is excluded (the first
+        # result is *after* start).
+        kwargs.update(Marker=__prev_str(start))
+    if end is not None:
+        if not end.startswith(path):
+            end = os.path.join(path, end)
+    if not recursive:
+        kwargs.update(Delimiter='/')
+        if not path.endswith('/'):
+            path += '/'
+    kwargs.update(Prefix=path)
+    if limit is not None:
+        kwargs.update(PaginationConfig={'MaxItems': limit})
+
+    paginator = bucket.meta.client.get_paginator('list_objects')
+    for resp in paginator.paginate(Bucket=bucket.name, **kwargs):
+        q = []
+        if 'CommonPrefixes' in resp and list_dirs:
+            q = [S3Obj(f['Prefix'], None, None, None) for f in resp['CommonPrefixes']]
+        if 'Contents' in resp and list_objs:
+            q += [S3Obj(f['Key'], f['LastModified'], f['Size'], f['ETag']) for f in resp['Contents']]
+        # note: even with sorted lists, it is faster to sort(a+b)
+        # than heapq.merge(a, b) at least up to 10K elements in each list
+        q = sorted(q, key=attrgetter('key'))
+        if limit is not None:
+            q = q[:limit]
+            limit -= len(q)
+        for p in q:
+            if end is not None and p.key >= end:
+                return
+            yield p
+
+
+def __prev_str(s):
+    if len(s) == 0:
+        return s
+    s, c = s[:-1], ord(s[-1])
+    if c > 0:
+        s += chr(c - 1)
+    s += ''.join(['\u7FFF' for _ in range(10)])
+    return s

--- a/src/vptstools/scripts/config.template.ini
+++ b/src/vptstools/scripts/config.template.ini
@@ -1,0 +1,9 @@
+[baltrad_server]
+host = 127.0.0.1
+port = 3395
+username = user
+password = xxxxxxx
+datadir = data
+
+[destination_bucket]
+name = aloft

--- a/src/vptstools/scripts/constants.py
+++ b/src/vptstools/scripts/constants.py
@@ -1,0 +1,1 @@
+CONFIG_FILE = "config.ini"

--- a/src/vptstools/scripts/generate_coverage.py
+++ b/src/vptstools/scripts/generate_coverage.py
@@ -9,8 +9,8 @@ from pathlib import PurePath
 
 import boto3
 
-from constants import CONFIG_FILE
-from s3_list_helper import s3list
+from vptstools.scripts.constants import CONFIG_FILE
+from vptstools.s3_list_helper import s3list
 
 
 def main():

--- a/src/vptstools/scripts/generate_coverage.py
+++ b/src/vptstools/scripts/generate_coverage.py
@@ -1,0 +1,54 @@
+# Script that parse the whole aloft bucket and generate a coverage.csv file
+# After discussion with Peter, we decided to keep a simple file count per directory (all listed in a global CSV file, one row per "directory")
+import csv
+import os
+import tempfile
+from collections import defaultdict
+from configparser import ConfigParser
+from pathlib import PurePath
+
+import boto3
+
+from constants import CONFIG_FILE
+from s3_list_helper import s3list
+
+
+def main():
+    config = ConfigParser()
+    config.read(CONFIG_FILE)
+
+    bucket_name = config.get("destination_bucket", "name")
+
+    session = boto3.Session(profile_name="prod")
+    s3 = session.resource('s3')
+    bucket = s3.Bucket(bucket_name)
+
+    counter = defaultdict(int)
+
+    print("Looping over files to count")
+    for i, e in enumerate(s3list(bucket, "", recursive=True, list_dirs=True, list_objs=True)):
+        dir = PurePath(e.key).parent
+        counter[str(dir)] += 1
+        if i % 10000 == 0:
+            print(".", end="")
+
+
+    print("Done, will now generate coverage.csv")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmp_coverage_path = os.path.join(tmpdirname, "coverage.csv")
+        with open(tmp_coverage_path, 'w') as csvfile:
+            fieldnames = ['directory', 'file_count']
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+            writer.writeheader()
+
+            for k, v in counter.items():
+                writer.writerow({'directory': k, 'file_count': v})
+
+        print("File generated, will now upload it to S3")
+        bucket.upload_file(tmp_coverage_path, 'coverage.csv')
+        print("Done")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vptstools/scripts/transfer_baltrad_to_aloft.py
+++ b/src/vptstools/scripts/transfer_baltrad_to_aloft.py
@@ -1,0 +1,101 @@
+from ast import Tuple
+from constants import CONFIG_FILE
+
+# Simple Python script that:
+# - Connects via SFTP to the BALTRAD server
+# - For each VP file (pvol gets ignored), download the file from the server and upload it to the "aloft" S3 bucket
+
+# Designed to be executed daily via a simple cronjob (files disappear after a few days on the BALTRAD server)
+# Use a simple config file named config.ini. Create one by copying config.template.ini and filling in the values.
+# If file already exists at destination => do nothing
+import os
+import tempfile
+from configparser import ConfigParser
+
+import boto3
+import paramiko
+
+
+def s3_key_exists(key: str, bucket: str, s3_client) -> bool:
+    results = s3_client.list_objects(Bucket=bucket, Prefix=key)
+    return "Contents" in results
+
+
+def extract_metadata_from_filename(filename: str) -> Tuple[str, str, str, str]):
+    """Extract the metadata from the filename (format such as 'fropo_vp_20220809T051000Z_0xb')
+
+    All returned values are strings, month and days are 0-prefixed if they are single-digit.
+    """
+    elems = filename.split("_")
+    radar_code = elems[0]
+    timestamp = elems[2]
+
+    year = timestamp[0:4]
+    month_str = timestamp[4:6]
+    day_str = timestamp[6:8]
+
+    return radar_code, year, month_str, day_str
+
+
+def main():
+    print("1. Read configuration from file")
+    config = ConfigParser()
+    config.read(CONFIG_FILE)
+    baltrad_server_host = config.get("baltrad_server", "host")
+    baltrad_server_port = config.getint("baltrad_server", "port")
+    baltrad_server_username = config.get("baltrad_server", "username")
+    baltrad_server_password = config.get("baltrad_server", "password")
+    baltrad_server_datadir = config.get("baltrad_server", "datadir")
+
+    destination_bucket = config.get("destination_bucket", "name")
+
+    print("2. Establish SFTP connection")
+    paramiko.util.log_to_file("paramiko.log")
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(
+        paramiko.AutoAddPolicy()
+    )  # necessary to avoid "Server 'hostname' not found in known_hosts error
+    ssh.connect(
+        baltrad_server_host,
+        port=baltrad_server_port,
+        username=baltrad_server_username,
+        password=baltrad_server_password,
+    )
+    sftp = ssh.open_sftp()
+    sftp.chdir(baltrad_server_datadir)
+
+    print("3. Initialize S3/Boto3 client")
+    session = boto3.Session(profile_name="prod")
+    s3_client = session.client("s3")
+
+    print("Initialization complete, we can loop on files on the SFTP server")
+    for entry in sftp.listdir_iter():
+        if "_vp_" in entry.filename:  # PVOLs and other files are ignored
+            print(f"{entry.filename} is a VP file, we need to consider it... ", end="")
+
+            radar_code, year, month_str, day_str = extract_metadata_from_filename(
+                entry.filename
+            )
+            destination_key = f"baltrad/hdf5/{radar_code}/{year}/{month_str}/{day_str}/{entry.filename}"
+            if not s3_key_exists(destination_key, destination_bucket, s3_client):
+                print(
+                    f"{destination_key} does not exist at {destination_bucket}, we need to transfer it...",
+                    end="",
+                )
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    tmp_file_path = os.path.join(tmpdirname, entry.filename)
+                    sftp.get(entry.filename, tmp_file_path)
+                    print("SFTP download completed. ", end="")
+                    s3_client.upload_file(
+                        tmp_file_path, destination_bucket, destination_key
+                    )
+                    print("Upload to S3 completed!")
+            else:
+                print(
+                    f"{destination_key} already exists at {destination_bucket}, we skip it"
+                )
+    print("ALl done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/vptstools/scripts/transfer_baltrad_to_aloft.py
+++ b/src/vptstools/scripts/transfer_baltrad_to_aloft.py
@@ -1,6 +1,3 @@
-from ast import Tuple
-from constants import CONFIG_FILE
-
 # Simple Python script that:
 # - Connects via SFTP to the BALTRAD server
 # - For each VP file (pvol gets ignored), download the file from the server and upload it to the "aloft" S3 bucket
@@ -9,11 +6,14 @@ from constants import CONFIG_FILE
 # Use a simple config file named config.ini. Create one by copying config.template.ini and filling in the values.
 # If file already exists at destination => do nothing
 import os
+from ast import Tuple
 import tempfile
 from configparser import ConfigParser
 
 import boto3
 import paramiko
+
+from vptstools.scripts.constants import CONFIG_FILE
 
 
 def s3_key_exists(key: str, bucket: str, s3_client) -> bool:
@@ -21,7 +21,7 @@ def s3_key_exists(key: str, bucket: str, s3_client) -> bool:
     return "Contents" in results
 
 
-def extract_metadata_from_filename(filename: str) -> Tuple[str, str, str, str]):
+def extract_metadata_from_filename(filename: str) -> Tuple[str, str, str, str]:
     """Extract the metadata from the filename (format such as 'fropo_vp_20220809T051000Z_0xb')
 
     All returned values are strings, month and days are 0-prefixed if they are single-digit.

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ passenv =
     SETUPTOOLS_*
 extras =
     develop
+    transfer
 commands =
     pytest {posargs}
 
@@ -68,6 +69,7 @@ setenv =
     linkcheck: BUILD = linkcheck
 extras =
     develop
+    transfer
 commands =
     sphinx-build --color -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
 
@@ -98,6 +100,7 @@ usedevelop = true
 envdir = {toxinidir}/venv
 extras =
     develop
+    transfer
 deps =
     ipykernel
 commands =


### PR DESCRIPTION
Code from the currently running data transfer service integrated in the repo with minimal adjustments. With this PR, we have all the current code for the aloft data service together (which was spread into this repo, the odimh5 and data-repository repos).

To make sure users who just want to use the odimh5 functionalities and are not interested in the data transfer services, the package dependencies used for the data transfer are defined as `extras_require` with the `transfer` ID. AS mentioned in the updates README.md, user can either install the package without `pip install vptstools` or with `pip install vptstools[transfer]` transfer dependencies.