### PR TITLE
Accept uppercase within filename and convert to lowercase for vptstools parsing

### DIFF
--- a/src/vptstools/s3.py
+++ b/src/vptstools/s3.py
@@ -98,7 +98,7 @@ class OdimFilePath:
         """
 
         name_regex = re.compile(
-            r".*([a-z]{2})([a-z]{3})_([a-z]*)_(\d\d\d\d)(\d\d)(\d\d)T?"
+            r".*([a-zA-Z]{2})([a-zA-Z]{3})_([a-z]*)_(\d\d\d\d)(\d\d)(\d\d)T?"
             r"(\d\d)(\d\d)(?:Z|00)?.*\.h5"
         )
         match = re.match(name_regex, file_name)

--- a/src/vptstools/s3.py
+++ b/src/vptstools/s3.py
@@ -106,7 +106,7 @@ class OdimFilePath:
             file_name = Path(file_name).name
             country, radar, data_type, year, month, day, hour, minute = match.groups()
             radar_code = country + radar
-            return radar_code, data_type, year, month, day, hour, minute, file_name
+            return radar_code.lower(), data_type, year, month, day, hour, minute, file_name
         else:
             raise ValueError("File name is not a valid ODIM h5 file.")
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -85,6 +85,19 @@ class TestOdimFilePath:
                     "plrze_vp_20201027T172000Z_0x9.h5",
                 ),
             ),
+            (
+                    "uva/hdf5/2008/02/15/NLDBL_vp_20080215T0000_NL50_v0-3-20.h5",
+                    (
+                            "nldbl",
+                            "vp",
+                            "2008",
+                            "02",
+                            "15",
+                            "00",
+                            "00",
+                            "NLDBL_vp_20080215T0000_NL50_v0-3-20.h5",
+                    ),
+            ),
         ],
     )
     def test_parse_file_name(self, file_path, components):


### PR DESCRIPTION
The uva-data has the radarcode in uppercase. This PR makes sure the parsing correctly interprets the name components and returns them as lowercase.