### PR TITLE
Update matching version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
     # Avoid using all the resources/limits available by checking only
     # relevant branches and tags. Other branches can be checked via PRs.
     branches: [main]
-    tags: ['v(([0-9a-z])+(\.|-)?)+']  # Match tags that resemble a version
-  workflow_dispatch:  # Allow manually triggering the workflow
+    tags: ['v[0-9]*'] # Match tags that resemble a version
+  workflow_dispatch: # Allow manually triggering the workflow
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     # Avoid using all the resources/limits available by checking only
     # relevant branches and tags. Other branches can be checked via PRs.
     branches: [main]
-    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
+    tags: ['v(([0-9a-z])+(\.|-)?)+']  # Match tags that resemble a version
   workflow_dispatch:  # Allow manually triggering the workflow
 
 permissions:


### PR DESCRIPTION
@stijnvanhoey I think there were two issues with the previous regex.

1. It doesn't match `v0.4.0-alpha.1` or even `v0.3.0` for that matter.
2. The second expression is invalid regex (according to regex101).

The current version is more flexible. I did drop the matching for tags that do not start with `v`