### PR TITLE
Add files in current path also to filelist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install '${{ needs.prepare.outputs.wheel-distribution }}'
-          python -m pip install pytest moto[s3] pytest-cov
+          python -m pip install pytest moto[s3]<5.0 pytest-cov
       - name: Run unit tests on pinned dependencies
         run: >-
           pytest -rFEx --durations 10 --color yes  # pytest args

--- a/src/vptstools/bin/vph5_to_vpts.py
+++ b/src/vptstools/bin/vph5_to_vpts.py
@@ -197,7 +197,7 @@ def cli(modified_days_ago, path_s3_folder=None):
             shutil.rmtree(temp_folder_path)
         except Exception as exc:
             click.echo(f"[WARNING] - During conversion from HDF5 files of {source}/{radar_code} at "
-                       f"{year}-{month}-{day} to daily VPTS file, the following error occurred: {exc}.")
+                       f"{year}-{month}-{day} to daily VPTS file, the following error occurred: {type(exc).__name__} - {exc}.")
 
     click.echo("Finished creating daily VPTS files.")
 
@@ -245,7 +245,7 @@ def cli(modified_days_ago, path_s3_folder=None):
             )
         except Exception as exc:
             click.echo(f"[WARNING] - During conversion from HDF5 files of {source}/{radar_code} at "
-                       f"{year}-{month}-{day} to monthly VPTS file, the following error occurred: {exc}.")
+                       f"{year}-{month}-{day} to monthly VPTS file, the following error occurred: {type(exc).__name__} - {exc}.")
 
     click.echo("Finished creating monthly VPTS files.")
     click.echo("Finished VPTS update procedure.")

--- a/src/vptstools/bin/vph5_to_vpts.py
+++ b/src/vptstools/bin/vph5_to_vpts.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from itertools import chain
 from functools import partial
 import shutil
 from pathlib import Path
@@ -98,7 +99,8 @@ def cli(modified_days_ago, path_s3_folder=None):
                    f"Ignoring the modified date of the files.")
 
         inbo_s3 = s3fs.S3FileSystem(**storage_options)
-        odim5_files = inbo_s3.glob(f"{S3_BUCKET}/{path_s3_folder}/**/*.h5")
+        odim5_files = chain(inbo_s3.glob(f"{S3_BUCKET}/{path_s3_folder}/**/*.h5"),
+                            inbo_s3.glob(f"{S3_BUCKET}/{path_s3_folder}/*.h5"))
 
         days_to_create_vpts = (
             pd.DataFrame(odim5_files, columns=["file"])

--- a/src/vptstools/bin/vph5_to_vpts.py
+++ b/src/vptstools/bin/vph5_to_vpts.py
@@ -113,6 +113,9 @@ def cli(modified_days_ago, path_s3_folder=None):
                 }
             )
         )
+        if len(days_to_create_vpts) == 0:
+            raise Exception(f"No h5 files could be found in the current"
+                            f" path '{S3_BUCKET}/{path_s3_folder}'.")
 
     else:
         # Load the S3 manifest of today


### PR DESCRIPTION
As reported in https://github.com/enram/vptstools/issues/75 files in the current filepath enlisted are not found (the glob of s3fs behaves a bit different than a regular glob). This PR adds the current files to the file generator and provides a more useful information message when the routine fails on absence of files.

__Note__: the specific example of the issue `vph5_to_vpts --path-s3-folder baltrad/hdf5/bejab/2018/05/18` still fails, but this is due to the fact that the H5 files are not according the expected format as defined in the `VptsCsvV1` (v1) mapping. The files are missing certain fields. For example the file 'bejab_vp_20180518T101500Z_0x5.h5': 
- The h5 file 'root_source' does not contain an "NOD" key - `{'WMO': '06410', 'RAD': 'BX42', 'PLC': 'Jabbeke'}`
- The h5 file 'how' does not contain a "vcp" key - 
```
{'beamwidth': 1.0,
 'clutterMap': '',
 'comment': '',
 'dealiased': 0,
 'enddate': '20180518',
 'endtime': '101910',
 'filename_pvol': '/data/baltrad/projects/vol2bird/data/out/merged/bejab_pvol_20180518T101500Z_0x5.h5',
 'filename_vp': '/data/baltrad/projects/vol2bird/data/out/bejab_vp_20180518T101500Z_0x5.h5',
 'maxazim': 360.0,
 'maxrange': 25.0,
 'minazim': 0.0,
 'minrange': 5.0,
 'rcs_bird': 11.0,
 'sd_vvp_thresh': 2.0,
 'startdate': '20180518',
 'starttime': '101505',
 'task': 'vol2bird',
 'task_args':  ...<LONG_SECTION>,
 'task_version': '0.3.18',
 'wavelength': 5.333000183105469}
```

If I run the operation on a more recent folder, e.g. `vph5_to_vpts --path-s3-folder baltrad/hdf5/bejab/2022/10/02`, the conversion itself does run correctly.

__Remark__ that you probably rather run it on a higher/nested level anyway, e.g. `vph5_to_vpts --path-s3-folder baltrad/hdf5/bejab/2022/10` will create all the daily files of the month Ocotber 2022 in a single command or `vph5_to_vpts --path-s3-folder baltrad/hdf5/bejab/2022` all of the year 2022. This is more convenient than running it day by day yoruself.

