### PR TITLE
place moto[s3] module in single quotes to stop bash error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install '${{ needs.prepare.outputs.wheel-distribution }}'
-          python -m pip install pytest moto[s3]<5.0 pytest-cov
+          python -m pip install pytest 'moto[s3]<5.0' pytest-cov
       - name: Run unit tests on pinned dependencies
         run: >-
           pytest -rFEx --durations 10 --color yes  # pytest args


### PR DESCRIPTION
I merged #76, and it turns out the [test on pinned is still failing](https://github.com/enram/vptstools/actions/runs/8204863452/job/22441081317), /home/runner/work/_temp/6d4f39ee-94eb-4c5d-808c-5b737e23657e.sh: line 4: 5.0: No such file or directory

Indeed, running this line in my terminal I get the same error:

```

$> python -m pip install pytest moto[s3]<5.0 pytest-covov
bash: 5.0: No such file or directory

```


I found this issue: https://github.com/getmoto/moto/issues/3856

They suggest single quoting the moto[s3] module, which seems to work in my terminal. 

---

~~Is it safe to manually trigger the release workflow on this?~~ Hope so, because I triggered it!